### PR TITLE
Fix test fail on line ending differences (Mac/Win)

### DIFF
--- a/test/exe.test.js
+++ b/test/exe.test.js
@@ -43,7 +43,7 @@ describe('zxpSignCmd exe tests', function () {
         zxpSignCmd.selfSignedCert(certOptions, function (error, result) {
 
             expect(error).to.be.a('null');
-            expect(result).to.equal('Self-signed certificate generated successfully\r\n');
+            expect(result).to.match(/Self-signed certificate generated successfully/);
             done();
         });
     });
@@ -52,7 +52,7 @@ describe('zxpSignCmd exe tests', function () {
 
         zxpSignCmd.sign(options, function (error, result) {
             expect(error).to.be.a('null');
-            expect(result).to.equal('Signed successfully\r\n');
+            expect(result).to.match(/Signed successfully/);
             done();
         });
     });


### PR DESCRIPTION
Fixed:

    Uncaught AssertionError: expected 'Self-signed certificate generated successfully\n' to equal 'Self-signed certificate generated successfully\r\n'